### PR TITLE
for different source of null in metrics table adsabs/Team/issues/#59

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -49,6 +49,7 @@ class ADSMasterPipelineCelery(ADSCelery):
                      'reference_num': bindparam('reference_num', required=False),
                      'rn_citations': bindparam('rn_citations', required=False),
                      'rn_citation_data': bindparam('rn_citation_data', required=False),
+                     'rn_citations_hist': bindparam('rn_citations_hist', required=False),
                     })
 
             self._metrics_table_update = self._metrics_table.update() \
@@ -68,6 +69,7 @@ class ADSMasterPipelineCelery(ADSCelery):
                      'reference_num': bindparam('reference_num', required=False),
                      'rn_citations': bindparam('rn_citations', required=False),
                      'rn_citation_data': bindparam('rn_citation_data', required=False),
+                     'rn_citations_hist': bindparam('rn_citations_hist', required=False),
                 })
 
 

--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -153,6 +153,7 @@ class MetricsModel(MetricsBase):
     reference_num = Column(Integer, default=0)
     rn_citations = Column(postgresql.REAL)
     rn_citation_data = Column(postgresql.JSON)
+    rn_citations_hist = Column(postgresql.JSON)
     modtime = Column(DateTime)
     
     
@@ -172,4 +173,5 @@ class MetricsModel(MetricsBase):
             reference_num = self.reference_num,
             rn_citations = self.rn_citations,
             rn_citation_data = self.rn_citation_data,
+            rn_citations_hist = self.rn_citations_hist,
             modtime = self.modtime and get_date(self.modtime).isoformat() or None)  


### PR DESCRIPTION
pervious nulls came from receiving of default values in protobuf.  this fixes the nulls caused by a missing column in the table definition