### PR TITLE
#40 solr index without fulltext as last resort

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -252,7 +252,6 @@ class ADSMasterPipelineCelery(ADSCelery):
         :param: solr_urls - list of strings, solr servers.
         """
         self.logger.debug('Updating solr: num_docs=%s solr_urls=%s', len(solr_docs), solr_urls)
-        
         out = solr_updater.update_solr(solr_docs, solr_urls, ignore_errors=True)
         failed_bibcodes = []
         errs = [x for x in out if x != 200]
@@ -261,17 +260,28 @@ class ADSMasterPipelineCelery(ADSCelery):
             self.mark_processed([x['bibcode'] for x in solr_docs], type='solr')
         else:
             self.logger.error('%s docs failed indexing', len(errs))
-            # recover from erros by inserting docs one by one
+            # recover from errors by inserting docs one by one
             for doc in solr_docs:
                 try:
+                    self.logger.error('trying individual update_solr %s', doc)
                     solr_updater.update_solr([doc], solr_urls, ignore_errors=False, commit=commit)
                     self.update_processed_timestamp(doc['bibcode'], type='solr')
                     self.logger.debug('%s success', doc['bibcode'])
                 except:
+                    # if individual insert fails, we try once more without fulltext
+                    # this bibcode needs to investigated as to why fulltext/body is failing
                     failed_bibcode = doc['bibcode']
-                    self.logger.error('Failed posting data to %s\noffending payload: %s', solr_urls, doc)
-                    failed_bibcodes.append(failed_bibcode)
-
+                    tmp_doc = dict(doc)
+                    tmp_doc.pop('body', None)
+                    try:
+                        solr_updater.update_solr([tmp_doc], solr_urls, ignore_errors=False, commit=commit)
+                        self.update_processed_timestamp(doc['bibcode'], type='solr')
+                        self.logger.debug('%s success without body', doc['bibcode'])
+                        self.logger.error('Failed posting fulltext to Solr for bibcode %s, non-fulltext ingested\nurls: %s, offending payload: %s', 
+                                          failed_bibcode, solr_urls, doc)
+                    except:
+                        self.logger.error('Failed posting bibcode %s to Solr even without fulltext\nurls: %s, offending payload %s', failed_bibcode, solr_urls, doc)
+                        failed_bibcodes.append(failed_bibcode)
         return failed_bibcodes
 
     

--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -235,7 +235,7 @@ def update_solr(json_records, solr_urls, ignore_errors=False, commit=False):
             if ignore_errors == True:
                 out.append(r.status_code)
             else:
-                raise Exception('Error posting data to SOLR: %s (err code: %s)' % (url, r.status_code))
+                raise Exception('Error posting data to SOLR: %s (err code: %s, err message:)' % (url, r.status_code, r.text))
     return out
             
     


### PR DESCRIPTION
if solr rejects individual record we try once more without fulltext and report either error no fulltext or error no index at all.