### PR TITLE
#39 data links support

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -32,7 +32,7 @@ class ADSMasterPipelineCelery(ADSCelery):
             MetricsBase.metadata.bind = self._metrics_engine
             self._metrics_table = Table('metrics', MetricsBase.metadata)
             register_after_fork(self._metrics_engine, self._metrics_engine.dispose)
-            
+
             self._metrics_table_insert = self._metrics_table.insert() \
                 .values({
                      'an_refereed_citations': bindparam('an_refereed_citations', required=False),
@@ -307,6 +307,8 @@ class ADSMasterPipelineCelery(ADSCelery):
             column = 'solr_processed'
         elif type == 'metrics':
             column = 'metrics_processed'
+        elif type == 'links':
+            column = 'datalinks_processed'
         else:
             column = 'processed'
         

--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -272,8 +272,8 @@ class ADSMasterPipelineCelery(ADSCelery):
                     # and if 'body' is in excpetion we assume Solr failed on body field
                     # then we try once more without fulltext
                     # this bibcode needs to investigated as to why fulltext/body is failing
+                    failed_bibcode = doc['bibcode']
                     if 'body' in str(e):
-                        failed_bibcode = doc['bibcode']
                         tmp_doc = dict(doc)
                         tmp_doc.pop('body', None)
                         try:

--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -65,11 +65,12 @@ class Records(Base):
     
     solr_processed = Column(UTCDateTime, default=None)
     metrics_processed = Column(UTCDateTime, default=None)
+    datalinks_processed = Column(UTCDateTime, default=None)
     status = Column(Enum('solr-failed', 'metrics-failed', 'success', name='status'))
     
     _date_fields = ['created', 'updated', 'processed',  # dates
                       'bib_data_updated', 'orcid_claims_updated', 'nonbib_data_updated',
-                      'fulltext_updated', 'metrics_updated',
+                      'fulltext_updated', 'metrics_updated', 'datalinks_processed',
                       'solr_processed', 'metrics_processed']
     _text_fields = ['id', 'bibcode', 'status']
     _json_fields = ['bib_data', 'orcid_claims', 'nonbib_data', 'metrics', 'fulltext']

--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -66,7 +66,7 @@ class Records(Base):
     solr_processed = Column(UTCDateTime, default=None)
     metrics_processed = Column(UTCDateTime, default=None)
     datalinks_processed = Column(UTCDateTime, default=None)
-    status = Column(Enum('solr-failed', 'metrics-failed', 'success', name='status'))
+    status = Column(Enum('solr-failed', 'metrics-failed', 'links-failed', 'success', name='status'))
     
     _date_fields = ['created', 'updated', 'processed',  # dates
                       'bib_data_updated', 'orcid_claims_updated', 'nonbib_data_updated',

--- a/adsmp/tasks.py
+++ b/adsmp/tasks.py
@@ -238,7 +238,7 @@ def task_index_records(bibcodes, force=False, update_solr=True, update_metrics=T
             app.mark_processed(links_bibcodes, type='links', status='success')
         else:
             logger.error('error sending links to %s, error = %s, sent data = %s ', links_url, r.text, tmp)
-
+            app.mark_processed(links_bibcodes, type=None, status='links-failed')
 
 @app.task(queue='delete-records')
 def task_delete_documents(bibcode):

--- a/config.py
+++ b/config.py
@@ -20,3 +20,7 @@ METRICS_SQLALCHEMY_URL = None #'postgres://postgres@localhost:5432/metrics'
 SOLR_URLS = ['http://localhost:9983/solr/collection1/update']
 SOLR_URL_NEW = 'http://localhost:9983/solr/collection1/query'
 SOLR_URL_OLD = 'http://localhost:9984/solr/collection1/query'
+
+# url for the update endpoint of the links resolver microservice
+# new links data is sent to this url, the mircoservice updates its datastore
+LINKS_RESOLVER_UDPATE_URL = 'http://localhost:8080/update'


### PR DESCRIPTION
master pipeline send new datalinks records to the links resolver microsevice endpoint, the microserive writes the data to a persistent datastore.

datalinks info is a subset of nonbib data.  master pipeline already stored all needed data, only the indexing had to change to send the info to the microservice update endpoint.