### PR TITLE
#39 tweak data links update

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,4 +23,5 @@ SOLR_URL_OLD = 'http://localhost:9984/solr/collection1/query'
 
 # url for the update endpoint of the links resolver microservice
 # new links data is sent to this url, the mircoservice updates its datastore
-LINKS_RESOLVER_UDPATE_URL = 'http://localhost:8080/update'
+# if None, updates are not sent
+LINKS_RESOLVER_UDPATE_URL = None  # 'http://localhost:8080/update'


### PR DESCRIPTION
the reindex force option is useful for sending partial records to solr.  since it makes less sense for datalinks update, this update now ignores the force flag.

