### PR TITLE
#55 add ads api token to datalinks http request

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -540,6 +540,7 @@ class ADSMasterPipelineCelery(ADSCelery):
         
 
         links_url = self.conf.get('LINKS_RESOLVER_UPDATE_URL')
+        api_token = self.conf.get('ADS_API_TOKEN', '')
         recs_to_process = set()
         failed_bibcodes = []
         crcs = {}
@@ -596,7 +597,7 @@ class ADSMasterPipelineCelery(ADSCelery):
             
         
         if len(links_data):
-            r = requests.put(links_url, data = links_data)
+            r = requests.put(links_url, data=links_data, headers={'Authorization': 'Bearer {}'.format(api_token)})
             if r.status_code == 200:
                 self.logger.info('sent %s datalinks to %s including %s', len(links_data), links_url, links_data[0])
                 update_crc('datalinks', links_data, set())

--- a/adsmp/tests/test_tasks.py
+++ b/adsmp/tests/test_tasks.py
@@ -29,7 +29,8 @@ class TestWorkers(unittest.TestCase):
             'SQLALCHEMY_ECHO': False,
             'SOLR_URLS': ['http://foo.bar.com/solr/v1'],
             'METRICS_SQLALCHEMY_URL': None,
-            'LINKS_RESOLVER_UPDATE_URL': 'http://localhost:8080/update'
+            'LINKS_RESOLVER_UPDATE_URL': 'http://localhost:8080/update',
+            'ADS_API_TOKEN': 'api_token'
             })
         tasks.app = self.app # monkey-patch the app object
         Base.metadata.bind = self.app._session.get_bind()
@@ -284,7 +285,8 @@ class TestWorkers(unittest.TestCase):
              patch('requests.put', return_value = r, new_callable=CopyingMock) as p:
             tasks.task_index_records(['linkstest'], update_solr=False, update_metrics=False, update_links=True, force=True)
             p.assert_called_with('http://localhost:8080/update',
-                                 data=[{'bibcode': 'linkstest', 'data_links_rows': [{'baz': 0}]}])
+                                 data=[{'bibcode': 'linkstest', 'data_links_rows': [{'baz': 0}]}],
+                                 headers={'Authorization': 'Bearer api_token'})
             
         
         rec = self.app.get_record(bibcode='linkstest')

--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ SOLR_URLS = ['http://localhost:9983/solr/collection1/update']
 SOLR_URL_NEW = 'http://localhost:9983/solr/collection1/query'
 SOLR_URL_OLD = 'http://localhost:9984/solr/collection1/query'
 
-# url for the update endpoint of the links resolver microservice
+# url and token for the update endpoint of the links resolver microservice
 # new links data is sent to this url, the mircoservice updates its datastore
 LINKS_RESOLVER_UDPATE_URL = 'http://localhost:8080/update'
+ADS_API_TOKEN = 'fixme'


### PR DESCRIPTION
actual token resides in eb-deply local config file

Is it really this simple to add the token?