### PR TITLE
fix datalinks update error

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -597,7 +597,7 @@ class ADSMasterPipelineCelery(ADSCelery):
             
         
         if len(links_data):
-            r = requests.put(links_url, data=links_data, headers={'Authorization': 'Bearer {}'.format(api_token)})
+            r = requests.put(links_url, data=json.dumps(links_data), headers={'Authorization': 'Bearer {}'.format(api_token)})
             if r.status_code == 200:
                 self.logger.info('sent %s datalinks to %s including %s', len(links_data), links_url, links_data[0])
                 update_crc('datalinks', links_data, set())

--- a/adsmp/tests/test_tasks.py
+++ b/adsmp/tests/test_tasks.py
@@ -285,7 +285,7 @@ class TestWorkers(unittest.TestCase):
              patch('requests.put', return_value = r, new_callable=CopyingMock) as p:
             tasks.task_index_records(['linkstest'], update_solr=False, update_metrics=False, update_links=True, force=True)
             p.assert_called_with('http://localhost:8080/update',
-                                 data=[{'bibcode': 'linkstest', 'data_links_rows': [{'baz': 0}]}],
+                                 data=json.dumps([{'bibcode': 'linkstest', 'data_links_rows': [{'baz': 0}]}]),
                                  headers={'Authorization': 'Bearer api_token'})
             
         


### PR DESCRIPTION
update to datalinks was generating a 400 error when json was sent as data, this fix convert it to a string