### PR TITLE
#69 send solr id from master, not import pipeline

### DIFF
--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -1,6 +1,7 @@
 import requests
 import json
 from adsputils import setup_logging, date2solrstamp
+import sys
 import time
 from collections import OrderedDict
 
@@ -273,7 +274,7 @@ def transform_json_record(db_record):
         if ts:
             ts = time.mktime(ts.timetuple())
         else:
-            ts = -1  
+            ts = sys.maxsize  # default to use option without timestamp
         timestamps.append((k, v, ts))
     timestamps.sort(key=lambda x: x[2])
     

--- a/adsmp/tests/test_solr_updater.py
+++ b/adsmp/tests/test_solr_updater.py
@@ -225,7 +225,7 @@ class TestSolrUpdater(unittest.TestCase):
              u'first_author_facet_hier': [u'0/Blecksmith, E',
               u'1/Blecksmith, E/Blecksmith, E.'],
              u'first_author_norm': u'Blecksmith, E',
-             u'id': u'1401492',
+             u'id': 1,  # from id in master database records table
              u'identifier': [u'2003adass..12..283B'],
              u'links_data': u'',
              'orcid_other' : [u'-', u'-', u'0000-0003-2377-2356', u'-'],


### PR DESCRIPTION
first take values from the column destinations without a timestamp to force id from master records table rather than id from import pipeline

note: this also changes the datatype for the value of id from string to int.  will that cause any problems for Solr?