### PR TITLE
Support for affiliation augmentation pipeline

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -139,26 +139,11 @@ class ADSMasterPipelineCelery(ADSCelery):
                 r.metrics = payload
                 r.metrics_updated = now
             elif type == 'augment':
-                # r.augments holds a dict, only key currently supported is affiliations
-                # use sequence entry to determine location in affiliation array
-                db_augments = r.augments
-                if db_augments is None or len(db_augments) is 0:
-                    db_augments = '{}'
-                db_augments = json.loads(db_augments)
-                affil_augments = db_augments.get('affiliations', [])
-                j = json.loads(payload)
-                # sequence count starts at 1, not 0
-                index = int(j['sequence'].split('/')[0]) - 1
-                if len(affil_augments) < index + 1:
-                    # here if db array is not long enough to hold new value
-                    # so we extend it by appending placeholder '-'
-                    affil_augments = affil_augments + [u'-'] * (index - len(affil_augments) + 1)
-                affil_augments[index] = j['affiliation']
-                db_augments['affiliations'] = affil_augments
+                # payload contains new value for affilation fields
+                # r.augments holds a dict, save it in database
                 oldval = 'not-stored'
-                r.augments = json.dumps(db_augments)
+                r.augments = payload
                 r.augments_updated = now
-
             else:
                 raise Exception('Unknown type: %s' % type)
             session.add(ChangeLog(key=bibcode, type=type, oldvalue=oldval))

--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -71,24 +71,15 @@ def extract_data_pipeline(data, solrdoc):
 
 
 def extract_augments_pipeline(db_augments, solrdoc):
-    """merge any agumented values into aff field and return"""
-    solr_aff = list(solrdoc.get('aff'))
-    if db_augments is None or len(db_augments) is 0:
-        db_augments = '{}'
-    if isinstance(db_augments, basestring):
-        db_augments = json.loads(db_augments)
-    affil_augments = db_augments.get('affiliations', [])
-    # loop over augmented affils and overwrite current values
-    for index, a in enumerate(affil_augments):
-        if len(a) > 1:
-            # here if have something larger than default '-' and need to overwrite
-            if len(solr_aff) < index + 1:
-                # extend array to make room for this entry
-                solr_aff = solr_aff + [u'-'] * (index - len(solr_aff) + 1)
-            logger.info('augmenting affiliation for %s, %s changed index %s to %s'
-                        % (solrdoc.get('bibcode'), solr_aff, index, a))
-            solr_aff[index] = a  # overwrite
-    return {'aff': solr_aff}
+    """retrieve expected agumented affiliation values"""
+    if db_augments is None or len(db_augments) == 0:
+        return {}
+    return {'aff': db_augments.get('aff', None),
+            'aff_abbrev': db_augments.get('aff_abbrev', None),
+            'aff_canonical': db_augments.get('aff_canonical', None),
+            'aff_facet': db_augments.get('aff_facet', None),
+            'aff_facet_hier': db_augments.get('aff_facet_hier', None),
+            'aff_id': db_augments.get('aff_id', None)}
 
 
 def extract_fulltext(data, solrdoc):
@@ -207,7 +198,7 @@ DB_COLUMN_DESTINATIONS = OrderedDict([
     ('id', 'id'),
     ('fulltext', extract_fulltext),
     ('#timestamps', get_timestamps), # use 'id' to be always called
-    ('augments', extract_augments_pipeline)  # over-writes existing field values
+    ('augments', extract_augments_pipeline)  # over aff field, adds aff_*
     ])
 
 

--- a/adsmp/tasks.py
+++ b/adsmp/tasks.py
@@ -32,7 +32,7 @@ def task_update_record(msg):
     status = app.get_msg_status(msg)
     type = app.get_msg_type(msg)
     bibcodes = []
-    
+
     if status == 'deleted':
         if type == 'metadata':
             task_delete_documents(msg.bibcode)
@@ -49,7 +49,6 @@ def task_update_record(msg):
             logger.debug('Deleted %s, result: %s', type, app.update_storage(msg.bibcode, type, None))
         
     elif status == 'active':
-        
         # save into a database
         # passed msg may contain details on one bibcode or a list of bibcodes
         if type == 'nonbib_records':
@@ -68,7 +67,7 @@ def task_update_record(msg):
             bibcodes.append(msg.bibcode)
             record = app.update_storage(msg.bibcode, 'augment',
                                         msg.toJSON(including_default_value_fields=True))
-            logger.debug('Saved passed message: %s', msg)
+            logger.debug('Saved augment message: %s', msg)
 
         else:
             # here when record has a single bibcode

--- a/adsmp/tests/test_app.py
+++ b/adsmp/tests/test_app.py
@@ -267,52 +267,6 @@ class TestAdsOrcidCelery(unittest.TestCase):
         with self.app.session_scope() as session:
             r = session.query(models.ChangeLog).filter_by(key='bibcode:abc').first()
             self.assertTrue(r.key, 'abc')
-
-        # verify affilation augments can arrive in any order
-        self.app.update_storage('bib_augment_test', 'augment',
-                                {'affiliation': 'CfA', 'sequence': '1/2'})
-        with self.app.session_scope() as session:
-            r = session.query(models.Records).filter_by(bibcode='bib_augment_test').first()
-            j = r.toJSON()
-            self.assertEquals(j['augments'], {'affiliations' : ['CfA']})
-            t = j['augments_updated']
-            self.assertTrue(now < t)
-
-        self.app.update_storage('bib_augment_test', 'augment',
-                                {'affiliation': 'Tufts', 'sequence': '2/2'})
-        with self.app.session_scope() as session:
-            r = session.query(models.Records).filter_by(bibcode='bib_augment_test').first()
-            j = r.toJSON()
-            self.assertEquals(j['augments'], {'affiliations': ['CfA', 'Tufts']})
-            t = j['augments_updated']
-            self.assertTrue(now < t)
-
-        self.app.update_storage('bib_augment_test2', 'augment',
-                                {'affiliation': 'Tufts', 'sequence': '2/2'})
-        with self.app.session_scope() as session:
-            r = session.query(models.Records).filter_by(bibcode='bib_augment_test2').first()
-            j = r.toJSON()
-            self.assertEquals(j['augments'], {'affiliations': ['-', 'Tufts']})
-            t = j['augments_updated']
-            self.assertTrue(now < t)
-
-        self.app.update_storage('bib_augment_test2', 'augment',
-                                {'affiliation': 'CfA', 'sequence': '1/2'})
-        with self.app.session_scope() as session:
-            r = session.query(models.Records).filter_by(bibcode='bib_augment_test2').first()
-            j = r.toJSON()
-            self.assertEquals(j['augments'], {'affiliations': ['CfA', 'Tufts']})
-            t = j['augments_updated']
-            self.assertTrue(now < t)
-
-        self.app.update_storage('bib_augment_test3', 'augment',
-                                {'affiliation': 'CfA', 'sequence': '4/4'})
-        with self.app.session_scope() as session:
-            r = session.query(models.Records).filter_by(bibcode='bib_augment_test3').first()
-            j = r.toJSON()
-            self.assertEquals(j['augments'], {'affiliations': ['-', '-', '-', 'CfA']})
-            t = j['augments_updated']
-            self.assertTrue(now < t)
             
         
     def test_rename_bibcode(self):

--- a/adsmp/tests/test_solr_updater.py
+++ b/adsmp/tests/test_solr_updater.py
@@ -172,12 +172,22 @@ class TestSolrUpdater(unittest.TestCase):
              u'citation_count_norm': .2,
              })
         self.app.update_storage('bibcode', 'augment',
-                                {'sequence': '2/4', 'affiliation': 'CfA'})
+                                {u'aff': [u'augment aff', u'-', u'-', u'-'],
+                                 u'aff_abbrev': [u'-', u'-', u'-', u'-'],
+                                 u'aff_canonical': [u'-', u'-', u'-', u'-'],
+                                 u'aff_facet': [u'-', u'-', u'-', u'-'],
+                                 u'aff_facet_hier': [u'-', u'-', u'-', u'-'],
+                                 u'aff_id': [u'-', u'-', u'-', u'-']})
         
         rec = self.app.get_record('bibcode')
         self.assertDictContainsSubset({u'abstract': u'abstract text',
              u'ack': u'aaa',
-             u'aff': [u'-', u'CfA', u'-', u'-'],
+             u'aff': [u'augment aff', u'-', u'-', u'-'],
+             u'aff_abbrev': [u'-', u'-', u'-', u'-'],
+             u'aff_canonical': [u'-', u'-', u'-', u'-'],
+             u'aff_facet': [u'-', u'-', u'-', u'-'],
+             u'aff_facet_hier': [u'-', u'-', u'-', u'-'],
+             u'aff_id': [u'-', u'-', u'-', u'-'],
              u'alternate_bibcode': [u'2003adass..12..283B'],
              u'author': [u'Blecksmith, E.', u'Paltani, S.', u'Rots, A.', u'Winkelman, S.'],
              u'author_count': 4,

--- a/adsmp/tests/test_tasks.py
+++ b/adsmp/tests/test_tasks.py
@@ -106,10 +106,39 @@ class TestWorkers(unittest.TestCase):
 
     def test_task_update_record_augments(self):
         with patch('adsmp.tasks.task_index_records.delay') as next_task:
-            tasks.task_update_record(AugmentAffiliationResponseRecord
-                                     (bibcode='2015ApJ...815..133S', author='me', affiliation='CfA', sequence='1/1'))
-            self.assertEquals(self.app.get_record(bibcode='2015ApJ...815..133S')['augments'],
-                              {'affiliations': ['CfA']})
+            d = {
+                u"aff": [
+                    u"Purdue University (United States)",
+                    u"Purdue University (United States)",
+                    u"Purdue University (United States)"
+                ], 
+                u"aff_abbrev": [
+                    u"NA",
+                    u"NA",
+                    u"NA"
+                ], 
+                u"aff_canonical": [
+                    u"-", 
+                    u"-", 
+                    u"-"
+                ],
+                u"aff_facet": [],
+                u"aff_facet_hier": [],
+                u"aff_id": [],
+                u"author": [
+                    u"Mikhail, E. M.",
+                    u"Kurtz, M. K.",
+                    u"Stevenson, W. H."
+                ], 
+                u"bibcode": u"1971SPIE...26..187M"
+            }
+            tasks.task_update_record(AugmentAffiliationResponseRecord(**d))
+            db_rec = self.app.get_record(bibcode='1971SPIE...26..187M')
+            db_rec['augments'].pop('status')
+            self.maxDiff = None
+            self.assertDictEqual(db_rec['augments'], d)
+
+
             self.assertFalse(next_task.called)
 
     def test_task_update_record_augments_list(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSPipelineUtils.git@v1.0.7
+git+https://github.com/adsabs/ADSPipelineUtils.git@v1.0.8
 alembic==0.9.1
 DateTime==4.1.1
 librabbitmq==1.6.1

--- a/run.py
+++ b/run.py
@@ -316,14 +316,6 @@ if __name__ == '__main__':
 
     elif args.augment:
         if args.filename:
-            data = {
-                'bibcode': '1971SPIE...26..187M',
-                'aff': ["Purdue University (United States)",
-                        "Purdue University (United States)",
-                        "Purdue University (United States)"],
-                'author': ["Mikhail, E. M.",
-                           "Kurtz, M. K.",
-                           "Stevenson, W. H."]}
             with open(args.filename, 'r') as f:
                 for line in f:
                     bibcode = line.strip()
@@ -331,7 +323,7 @@ if __name__ == '__main__':
                         # read db record for current aff value, send to queue
                         # aff values omes from bib pipeline
                         
-                        app.request_aff_augment(bibcode, data)
+                        app.request_aff_augment(bibcode)
         
     elif args.reindex:
         update_solr = 's' in args.reindex.lower()

--- a/run.py
+++ b/run.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
                         action='store_true',
                         default=False,
                         help='Submits records for processing even if they dont have any new updates (use this to rebuild index).')
-    
+
     parser.add_argument('-s', 
                         '--since', 
                         dest='since', 
@@ -256,12 +256,18 @@ if __name__ == '__main__':
                         action='store_true',
                         default=False,
                         help='Update persistent store even when checksum match says it is redundant')
+
+    parser.add_argument('-a',
+                        '--augment',
+                        dest='augment',
+                        action='store_true',
+                        default=False,
+                        help='sends bibcodes to augment affilation pipeline, works with --filename')
     
     args = parser.parse_args()
     
     if args.bibcodes:
         args.bibcodes = args.bibcodes.split(' ')
-    
     
     if args.kv:
         print_kvs()
@@ -300,13 +306,32 @@ if __name__ == '__main__':
         if args.filename:
             print 'deleting bibcodes from file via queue'
             bibs = []
-            with open(args.filename) as f:
+            with open(args.filename, 'r') as f:
                 for line in f:
                     bibcode = line.strip()
                     if bibcode:
                         tasks.task_delete_documents(bibcode)
         else:
             print 'please provide a file of bibcodes to delete via -n'
+
+    elif args.augment:
+        if args.filename:
+            data = {
+                'bibcode': '1971SPIE...26..187M',
+                'aff': ["Purdue University (United States)",
+                        "Purdue University (United States)",
+                        "Purdue University (United States)"],
+                'author': ["Mikhail, E. M.",
+                           "Kurtz, M. K.",
+                           "Stevenson, W. H."]}
+            with open(args.filename, 'r') as f:
+                for line in f:
+                    bibcode = line.strip()
+                    if bibcode:
+                        # read db record for current aff value, send to queue
+                        # aff values omes from bib pipeline
+                        
+                        app.request_aff_augment(bibcode, data)
         
     elif args.reindex:
         update_solr = 's' in args.reindex.lower()
@@ -336,6 +361,7 @@ if __name__ == '__main__':
             reindex(since=args.since, batch_size=args.batch_size, force_indexing=args.force_indexing, 
                     update_solr=update_solr, update_metrics=update_metrics, 
                     update_links = update_links, force_processing=args.force_processing, ignore_checksums=args.ignore_checksums)
+
         
             
 


### PR DESCRIPTION
We sent data from the affiliation augmentation pipeline to test master pipeline for ~1m records.  We sent data for one bibcode from test master to Solr.  Solr record looks correct.

We still have an issue sending requests from master to affiliation augmentation.  This gives:
```
"Received and deleted unknown message.  Wrong destination
```
We will fix this problem next week with a different PR.  We need to deploy this PR now to get the augmented affiliation data in for AAS.