### PR TITLE
cleanup unused values sent to resolver

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -732,7 +732,7 @@ class ADSMasterPipelineCelery(ADSCelery):
                     if url:
                         resolver_record = {'bibcode': bibcode,
                                            'data_links_rows': [{'url': [url],
-                                                                'title': '', 'count': 0,
+                                                                'title': [''], 'item_count': 0,
                                                                 'link_type': 'ESOURCE',
                                                                 'link_sub_type': 'EPRINT_HTML'}]}
                 except (KeyError, ValueError):

--- a/adsmp/tests/test_app.py
+++ b/adsmp/tests/test_app.py
@@ -363,8 +363,8 @@ class TestAdsOrcidCelery(unittest.TestCase):
         self.assertEqual('http://arxiv.org/abs/1902.09522', first['url'][0])
         self.assertEqual('ESOURCE', first['link_type'])
         self.assertEqual('EPRINT_HTML', first['link_sub_type'])
-        self.assertEqual('', first['title'])
-        self.assertEqual(0, first['count'])
+        self.assertEqual([''], first['title'])
+        self.assertEqual(0, first['item_count'])
 
         bib_and_nonbib = {'bibcode': 'asdf',
                           'bib_data':


### PR DESCRIPTION
although they are not used, they must be of the right type