### PR TITLE
fix directory bug in reindex

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -7,7 +7,7 @@ import pickle
 import requests
 import time
 
-homedir = os.path.dirname(os.path.dirname(__file__))
+homedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if homedir not in sys.path:
     sys.path.append(homedir)
 


### PR DESCRIPTION
homedir was set to empty string so lockfile was created in system root directory
and python run.py failed with file run.py not found