### PR TITLE
support for converting aff to virtual field

### DIFF
--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -83,7 +83,7 @@ def extract_augments_pipeline(db_augments, solrdoc):
             'aff_facet': db_augments.get('aff_facet', None),
             'aff_facet_hier': db_augments.get('aff_facet_hier', None),
             'aff_id': db_augments.get('aff_id', None),
-            'aff_raw': db_augments.get('aff', None),  # string originaly sent to augment
+            'aff_raw': db_augments.get('aff_raw', None),
             'institution': db_augments.get('institution', None)}
 
 

--- a/adsmp/tests/test_solr_updater.py
+++ b/adsmp/tests/test_solr_updater.py
@@ -185,6 +185,7 @@ class TestSolrUpdater(unittest.TestCase):
                                  u'aff_facet': [u'-', u'-', u'-', u'-'],
                                  u'aff_facet_hier': [u'-', u'-', u'-', u'-'],
                                  u'aff_id': [u'-', u'-', u'-', u'-'],
+                                 u'aff_raw': [u'augment pipeline aff', u'-', u'-', u'-'],
                                  u'institution': [u'-', u'-', u'-', u'-']})
 
         rec = self.app.get_record('bibcode')
@@ -300,10 +301,11 @@ class TestSolrUpdater(unittest.TestCase):
             else:
                 self.assertEquals(x[f], '2017-09-19T21:17:12.026474Z')
 
+        rec = self.app.get_record('bibcode')
         x = solr_updater.transform_json_record(rec)
-        self.assertFalse('aff' in x, 'virtual field should not be in solr output')
-        self.assertEquals(x['aff_raw'], rec['augments']['aff'], 'solr record should prioritize aff data from augment')
-        self.assertEquals(x['aff_abbrev'], rec['augments']['aff_abbrev'], 'solr record should include all augment data')
+        self.assertFalse('aff' in x)  #  virtual field should not be in solr output
+        self.assertEquals(x['aff_raw'], rec['augments']['aff'])  # solr record should prioritize aff data from augment
+        self.assertEquals(x['aff_abbrev'], rec['augments']['aff_abbrev'])  # solr record should include augment data
         
 
     def test_links_data_merge(self):

--- a/adsmp/tests/test_tasks.py
+++ b/adsmp/tests/test_tasks.py
@@ -129,6 +129,7 @@ class TestWorkers(unittest.TestCase):
                 u"aff_facet": [],
                 u"aff_facet_hier": [],
                 u"aff_id": [],
+                u"aff_raw": [],
                 u"author": [
                     u"Mikhail, E. M.",
                     u"Kurtz, M. K.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/adsabs/ADSPipelineUtils.git@v1.0.15
+git+https://github.com/adsabs/ADSPipelineUtils.git@v1.1.0
 alembic==0.9.1
 DateTime==4.1.1
 librabbitmq==1.6.1


### PR DESCRIPTION
prioritzes aff data from affilation pipeline
when it is not available, set aff_raw using aff field from bib/import pipeline
solf virtual field aff is never set

one could also change the bib/import data pipeline and rename property aff to aff_raw