### PR TITLE
reduce default process/index batch size

### DIFF
--- a/run.py
+++ b/run.py
@@ -300,7 +300,7 @@ if __name__ == '__main__':
                         '--batch_size',
                         dest='batch_size',
                         action='store',
-                        default=1000,
+                        default=100,
                         type=int,
                         help='How many records to process/index in one batch')
 


### PR DESCRIPTION
from 1000 to 100
it appears the size of 1000 can cause problems at least for resolver updates