### PR TITLE
Bugfix: Get citation count from nonbib data instead of metrics

### DIFF
--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -62,8 +62,8 @@ def extract_data_pipeline(data, solrdoc):
               nedid=nedid,
               nedtype=nedtype,
               ned_object_facet_hier=ned_object_facet_hier,
+              citation_count=data.get('citation_count', 0),
               citation_count_norm=data.get('citation_count_norm', 0)
-              citation_count=data.get('citation_count', 0)
     )
     if data.get('links_data', None):
         d['links_data'] = data['links_data']

--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -11,11 +11,8 @@ logger = setup_logging('solr_updater')
 def extract_metrics_pipeline(data, solrdoc):
 
     citation=data.get('citations', [])
-    citation_count=len(citation)
 
-    return dict(citation=citation,
-                citation_count=citation_count,
-                )
+    return dict(citation=citation)
 
 def extract_data_pipeline(data, solrdoc):
 
@@ -66,6 +63,7 @@ def extract_data_pipeline(data, solrdoc):
               nedtype=nedtype,
               ned_object_facet_hier=ned_object_facet_hier,
               citation_count_norm=data.get('citation_count_norm', 0)
+              citation_count=data.get('citation_count', 0)
     )
     if data.get('links_data', None):
         d['links_data'] = data['links_data']

--- a/adsmp/tests/test_solr_updater.py
+++ b/adsmp/tests/test_solr_updater.py
@@ -168,6 +168,7 @@ class TestSolrUpdater(unittest.TestCase):
              u'simbad_objects': [u'2419335 sim', u'3111723 sim*'],
              u'ned_objects': [u'2419335 HII', u'3111723 ned*'],
              u'grants': [u'2419335 g', u'3111723 g*'],
+             u'citation_count': 6,
              u'citation_count_norm': .2,
              })
         rec = self.app.get_record('bibcode')


### PR DESCRIPTION
- This avoid having non-syncronized citation count and normalized citation count since nonbib data and metrics can be received in separate moment (thus master was mixing new norm citation count with old citation count)