### PR TITLE
Ideas and suggestions for PR #145

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Short Summary
 
-This pipeline is collecting results from the sub-ordinate pipelines (bibliographic, non-bibliographic, fulltext, orcid claims, metrics). It also updates SOLR, Metrics DB and link resolver.
+This pipeline is collecting results from the sub-ordinate pipelines (bibliographic, non-bibliographic, fulltext, orcid claims, metrics). It also updates production data stores: SOLR, Metrics DB and link resolver.
 
 
 ## Queues and objects
@@ -13,6 +13,10 @@ This pipeline is collecting results from the sub-ordinate pipelines (bibliograph
     - update-record: input from the 'other' pipelines is collected here
     - index-record: internal queue, it forwards data to solr/metrics
     - delete-record: removes from solr/metrics db
+    - rebuild-index: used during weekly rebuild of solr
+    - index-solr: internal queue of records to send to solr
+    - index-metrics: internal queue of records to send to metrics on aws
+    - index-data-links-resolver: internal queue of records to send to data links resolver
 
 ## Setup (recommended)
 
@@ -25,7 +29,7 @@ This pipeline is collecting results from the sub-ordinate pipelines (bibliograph
 
 ## Important note
 
-The pipeline will NOT send anything to SOLR/Metrics DB by default. You should trigger the update using a cronjob. There are two important modes:
+The pipeline will NOT send anything to SOLR/Metrics DB/data links resolver by default. You should trigger the update using a cronjob. There are two important modes:
 
     - normal mode (`python run.py -r`): will discover all updates that happened since the last invocation
         of the normal mode and will send them to the `index-records` queue; the parameter force will be set to False; hence only documents that have both metadata, orcid claims, and non-bib data will get sent to solr
@@ -41,45 +45,6 @@ The pipeline will NOT send anything to SOLR/Metrics DB by default. You should tr
   17:01-22:00 | normal mode, invoked every 5 mins
   22:01-23:59 | forced mode, catch updates 
 
-
-## Solr Tweaks
-
-Sometimes we want to modify Solr records for specific bibcodes.  The most common use case is when we add a new Solr field.  Previously, we developed and deployed pipeline code to compute the new field, passed this data to master and extended master to send the new field to Solr.  For very complex fields, this takes too long.  It delays the prototyping of UI code until all pipeline changes are in production.  Solr tweaks allows deployment of test values for a small number of bibcodes to Solr.  Simply put the values in a properly formatted .json file in the /app/tweak_files directory and restart the workers.  Workers must be restarted because the read all the tweak files during initialization.  Solr tweak files contain:
-```
-{
-    "docs": [
-        {
-            "bibcode": "1971SPIE...26..187M",
-            "aff": [
-                "Purdue University (United States)",
-                "Purdue University (United States)",
-                "Purdue University (United States)"
-            ],
-            "aff_abbrev": [
-                "NA",
-                "NA",
-                "NA"
-            ],
-            "aff_canonical": [
-                "Not Matched",
-                "Not Matched",
-                "Not Matched"
-            ],
-            "aff_facet_hier": [],
-            "author": [
-                "Mikhail, E. M.",
-                "Kurtz, M. K.",
-                "Stevenson, W. H."
-            ],
-            "title": [
-                "Metric Characteristics Of Holographic Imagery"
-            ]
-        },
-	...
-```
-Just before master sends a Solr doc to Solr, master checks if there is a tweak for the current bibcode.  If so, the Solr doc dict is updated with the tweak dict.  New key/value pairs are added and, where the key already exists in the Solr doc dict, its value is changed to match the value in the tweak dict.
-
-Solr tweaks do not change any values in master's Records table.  To remove the tweaks, delete the tweak file(s), restart the celery workers and reindex the tweaked bibcodes.  A bibcode should not be repeated either in a single tweak file or in multiple tweak files.  When multiple tweaks for a given bibcode are provided only one tweak is applied and an error is logged.
 
 ## Testing
 

--- a/adsmp/exceptions.py
+++ b/adsmp/exceptions.py
@@ -9,4 +9,4 @@ class ProcessingException(Exception):
     ErrorHandler."""
     pass
 
-        
+

--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -19,7 +19,7 @@ MetricsBase = declarative_base()
 
 class UTCDateTime(types.TypeDecorator):
     impl = TIMESTAMP
-    
+
     def process_bind_param(self, value, engine):
         if isinstance(value, basestring):
             return get_date(value).astimezone(tzutc())
@@ -56,7 +56,7 @@ class Records(Base):
     # holds a dict of augments to be merged
     # currently only supported key is 'affiliations'
     #  with the value an array holding affiliation strings and '-' placeholders
-    augments = Column(Text) 
+    augments = Column(Text)
 
     # when data is received we set the updated timestamp
     bib_data_updated = Column(UTCDateTime, default=None)
@@ -69,17 +69,17 @@ class Records(Base):
     created = Column(UTCDateTime, default=get_date)
     updated = Column(UTCDateTime, default=get_date)
     processed = Column(UTCDateTime)
-    
+
     solr_processed = Column(UTCDateTime, default=None)
     metrics_processed = Column(UTCDateTime, default=None)
     datalinks_processed = Column(UTCDateTime, default=None)
-    
+
     solr_checksum = Column(String(10), default=None)
     metrics_checksum = Column(String(10), default=None)
     datalinks_checksum = Column(String(10), default=None)
-    
+
     status = Column(Enum('solr-failed', 'metrics-failed', 'links-failed', 'retrying', 'success', name='status'))
-    
+
     _date_fields = ['created', 'updated', 'processed',  # dates
                     'bib_data_updated', 'orcid_claims_updated', 'nonbib_data_updated',
                     'fulltext_updated', 'metrics_updated', 'augments_updated',
@@ -151,7 +151,7 @@ class MetricsModel(MetricsBase):
     __bind_key__ = 'metrics'
     id = Column(Integer, primary_key=True)
     bibcode = Column(String, nullable=False, index=True, unique=True)
-    
+
     an_citations = Column(postgresql.REAL)
     an_refereed_citations = Column(postgresql.REAL)
     author_num = Column(Integer, default=1, server_default=text("1::integer"))
@@ -166,7 +166,7 @@ class MetricsModel(MetricsBase):
     rn_citations = Column(postgresql.REAL)
     rn_citation_data = Column(postgresql.JSON)
     modtime = Column(DateTime)
-    
+
     def toJSON(self):
         return dict(id=self.id,
                     bibcode=self.bibcode,

--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -19,11 +19,12 @@ MetricsBase = declarative_base()
 
 class UTCDateTime(types.TypeDecorator):
     impl = TIMESTAMP
+    
     def process_bind_param(self, value, engine):
         if isinstance(value, basestring):
             return get_date(value).astimezone(tzutc())
         elif value is not None:
-            return value.astimezone(tzutc()) # will raise Error is not datetime
+            return value.astimezone(tzutc())  # will raise Error is not datetime
 
     def process_result_value(self, value, engine):
         if value is not None:
@@ -104,7 +105,7 @@ class Records(Base):
                     doc[f] = get_date(getattr(self, f))
                 else:
                     doc[f] = None
-            for f in Records._json_fields: # json
+            for f in Records._json_fields:  # json
                 if load_only and f not in load_only:
                     continue
                 v = getattr(self, f, None)
@@ -124,7 +125,6 @@ class ChangeLog(Base):
     oldvalue = Column(Text)
     permanent = Column(Boolean, default=False)
 
-
     def toJSON(self):
         return {'id': self.id,
                 'key': self.key,
@@ -141,7 +141,7 @@ class IdentifierMapping(Base):
     target = Column(String(255))
 
     def toJSON(self):
-        return {'key': self.key, 'target': self.target }
+        return {'key': self.key, 'target': self.target}
 
 
 ## This definition is copied directly from: https://github.com/adsabs/metrics_service/blob/master/service/models.py
@@ -157,7 +157,7 @@ class MetricsModel(MetricsBase):
     author_num = Column(Integer, default=1, server_default=text("1::integer"))
     citations = Column(postgresql.ARRAY(String), default=[], server_default=text("(ARRAY[]::varchar[])"))
     citation_num = Column(Integer, default=0)
-    downloads = Column(postgresql.ARRAY(Integer),default=[])
+    downloads = Column(postgresql.ARRAY(Integer), default=[])
     reads = Column(postgresql.ARRAY(Integer), default=[])
     refereed = Column(Boolean, default=False)
     refereed_citations = Column(postgresql.ARRAY(String), default=[])
@@ -167,21 +167,20 @@ class MetricsModel(MetricsBase):
     rn_citation_data = Column(postgresql.JSON)
     modtime = Column(DateTime)
     
-    
     def toJSON(self):
-        return dict(id = self.id,
-            bibcode = self.bibcode,
-            an_citations = self.an_citations,
-            an_refereed_citations = self.an_refereed_citations,
-            author_num = self.author_num,
-            citations = self.citations,
-            citation_num = self.citation_num,
-            downloads = self.downloads,
-            reads = self.reads,
-            refereed = self.refereed,
-            refereed_citations = self.refereed_citations,
-            refereed_citation_num = self.refereed_citation_num,
-            reference_num = self.reference_num,
-            rn_citations = self.rn_citations,
-            rn_citation_data = self.rn_citation_data,
-            modtime = self.modtime and get_date(self.modtime).isoformat() or None)  
+        return dict(id=self.id,
+                    bibcode=self.bibcode,
+                    an_citations=self.an_citations,
+                    an_refereed_citations=self.an_refereed_citations,
+                    author_num=self.author_num,
+                    citations=self.citations,
+                    citation_num=self.citation_num,
+                    downloads=self.downloads,
+                    reads=self.reads,
+                    refereed=self.refereed,
+                    refereed_citations=self.refereed_citations,
+                    refereed_citation_num=self.refereed_citation_num,
+                    reference_num=self.reference_num,
+                    rn_citations=self.rn_citations,
+                    rn_citation_data=self.rn_citation_data,
+                    modtime=self.modtime and get_date(self.modtime).isoformat() or None)

--- a/adsmp/solr_updater.py
+++ b/adsmp/solr_updater.py
@@ -4,22 +4,13 @@ import json
 from adsputils import date2solrstamp
 import sys
 import time
-from collections import OrderedDict
 
-# ============================= INITIALIZATION ==================================== #
-# - Use app logger:
-#import logging
-#logger = logging.getLogger('master-pipeline')
-# - Or individual logger for this file:
 from adsputils import setup_logging, load_config
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
 config = load_config(proj_home=proj_home)
 logger = setup_logging(__name__, proj_home=proj_home,
-                        level=config.get('LOGGING_LEVEL', 'INFO'),
-                        attach_stdout=config.get('LOG_STDOUT', False))
-
-
-# =============================== FUNCTIONS ======================================= #
+                       level=config.get('LOGGING_LEVEL', 'INFO'),
+                       attach_stdout=config.get('LOG_STDOUT', False))
 
 
 def extract_metrics_pipeline(data, solrdoc):
@@ -110,6 +101,7 @@ def extract_augments_pipeline(db_augments, solrdoc):
             'aff_raw': db_augments.get('aff_raw', None),
             'institution': db_augments.get('institution', None)}
 
+
 def modify_affiliations(data, solrdoc):
     """Make sure that preference is given to affiliations extracted
     by augment pipeline
@@ -119,9 +111,10 @@ def modify_affiliations(data, solrdoc):
     if solrdoc.get('aff', None):
         solrdoc['aff_raw'] = solrdoc.get('aff', None)
 
+
 def extract_fulltext(data, solrdoc):
     out = {}
-    for x,f in (('body', 'body'), ('acknowledgements', 'ack'), ('facility', 'facility')):
+    for x, f in (('body', 'body'), ('acknowledgements', 'ack'), ('facility', 'facility')):
         if x in data:
             out[f] = data[x]
     return out
@@ -138,6 +131,7 @@ def generate_hier_facet(*levels):
         tmpl += '/{}'
         i += 1
     return out
+
 
 def get_orcid_claims(data, solrdoc):
     out = {}
@@ -175,14 +169,17 @@ def map_simbad_type(otype):
     else:
         return u'Other'
 
+
 _o_types = {}
-[_o_types.__setitem__(x, u'Galaxy') for x in ["G","GClstr","GGroup","GPair","GTrpl","G_Lens","PofG"]]
-[_o_types.__setitem__(x, u'Nebula') for x in ['Neb','PN','RfN']]
+[_o_types.__setitem__(x, u'Galaxy') for x in ["G", "GClstr", "GGroup", "GPair", "GTrpl", "G_Lens", "PofG"]]
+[_o_types.__setitem__(x, u'Nebula') for x in ['Neb', 'PN', 'RfN']]
 [_o_types.__setitem__(x, u'HII Region') for x in ['HII']]
 [_o_types.__setitem__(x, u'X-ray') for x in ['X']]
 [_o_types.__setitem__(x, u'Radio') for x in ['Maser', 'HI']]
 [_o_types.__setitem__(x, u'Infrared') for x in ['IrS']]
-[_o_types.__setitem__(x, u'Star') for x in ['Blue*','C*','exG*','Flare*','Nova','Psr','Red*','SN','SNR','V*','VisS','WD*','WR*']]
+[_o_types.__setitem__(x, u'Star') for x in ['Blue*', 'C*', 'exG*', 'Flare*', 'Nova', 'Psr', 'Red*', 'SN', 'SNR', 'V*', 'VisS', 'WD*', 'WR*']]
+
+
 def map_ned_type(otype):
     """
     Maps a native NED object type to a subset of basic classes
@@ -200,7 +197,6 @@ def map_ned_type(otype):
         return _o_types.get(otype, u'Other')
 
 
-
 # When building SOLR record, we grab data from the database and insert them
 # into the dictionary with the following conventions:
 
@@ -209,11 +205,13 @@ def map_ned_type(otype):
 # None == ignore the value completely
 # function == receives the data (and solr doc as built already), should return dict
 fmap = dict(metadata_mtime='bib_data_updated',
-           nonbib_mtime='nonbib_data_updated',
-           fulltext_mtime='fulltext_updated',
-           orcid_mtime='orcid_claims_updated',
-           metrics_mtime='metrics_updated'
-           )
+            nonbib_mtime='nonbib_data_updated',
+            fulltext_mtime='fulltext_updated',
+            orcid_mtime='orcid_claims_updated',
+            metrics_mtime='metrics_updated'
+)
+
+
 def get_timestamps(db_record, out):
     out = {}
     last_update = None
@@ -235,7 +233,7 @@ DB_COLUMN_DESTINATIONS = [
     ('metrics', extract_metrics_pipeline),
     ('id', 'id'),
     ('fulltext', extract_fulltext),
-    ('#timestamps', get_timestamps), # use 'id' to be always called
+    ('#timestamps', get_timestamps),  # use 'id' to be always called
     ('augments', extract_augments_pipeline),  # over aff field, adds aff_*
     ('#affiliations', modify_affiliations)
     ]
@@ -247,10 +245,10 @@ def delete_by_bibcodes(bibcodes, urls):
 
     deleted = []
     failed = []
-    headers = {"Content-Type":"application/json"}
+    headers = {"Content-Type": "application/json"}
     for bibcode in bibcodes:
         logger.info("Delete: %s" % bibcode)
-        data = json.dumps({'delete':{"query":'bibcode:"%s"' % bibcode}})
+        data = json.dumps({'delete': {"query": 'bibcode:"%s"' % bibcode}})
         i = 0
         for url in urls:
             r = requests.post(url, headers=headers, data=data)
@@ -261,7 +259,6 @@ def delete_by_bibcodes(bibcodes, urls):
         else:
             failed.append(bibcode)
     return (deleted, failed)
-
 
 
 def update_solr(json_records, solr_urls, ignore_errors=False, commit=False):
@@ -293,7 +290,6 @@ def update_solr(json_records, solr_urls, ignore_errors=False, commit=False):
     return out
 
 
-
 def transform_json_record(db_record):
     out = {'bibcode': db_record['bibcode']}
 
@@ -313,7 +309,7 @@ def transform_json_record(db_record):
         if db_record.get(field, None):
             if target:
                 if callable(target):
-                    x = target(db_record.get(field), out) # in the interest of speed, don't create copy of out
+                    x = target(db_record.get(field), out)  # in the interest of speed, don't create copy of out
                     if x:
                         out.update(x)
                 else:
@@ -326,7 +322,7 @@ def transform_json_record(db_record):
 
         elif field.startswith('#'):
             if callable(target):
-                x = target(db_record, out) # in the interest of speed, don't create copy of out
+                x = target(db_record, out)  # in the interest of speed, don't create copy of out
                 if x:
                     out.update(x)
 

--- a/adsmp/tasks.py
+++ b/adsmp/tasks.py
@@ -114,7 +114,7 @@ def task_rebuild_index(bibcodes, force=False, update_solr=True, update_metrics=T
 
 @app.task(queue='index-records')
 def task_index_records(bibcodes, force=False, update_solr=True, update_metrics=True, update_links=True, commit=False,
-                       ignore_checksums=False, solr_targets=None, update_timestamps=True):
+                       ignore_checksums=False, solr_targets=None, update_timestamps=True, priority=0):
     """
     Sends data to production systems: solr, metrics and resolver links
 

--- a/adsmp/tasks.py
+++ b/adsmp/tasks.py
@@ -127,7 +127,7 @@ def task_index_records(bibcodes, force=False, update_solr=True, update_metrics=T
     reindex_records(bibcodes, force=force, update_solr=update_solr, update_metrics=update_metrics, update_links=update_links, commit=commit,
                     ignore_checksums=ignore_checksums, solr_targets=solr_targets, set_processed_timestamp=set_processed_timestamp)
 
-    
+
 @app.task(queue='index-solr')
 def task_index_solr(solr_records, priority=0, commit=False, solr_targets=None, set_processed_timestamp=True):
     app.index_solr(solr_records, solr_targets, commit, set_processed_timestamp)

--- a/adsmp/tests/test_run.py
+++ b/adsmp/tests/test_run.py
@@ -56,7 +56,7 @@ class TestFixDbDuplicates(unittest.TestCase):
             queue_bibcodes.assert_called_with([u'bibcode2', u'bibcode3'],
                                               force=True, ignore_checksums=True,
                                               update_links=True, update_metrics=True,
-                                              update_solr=True, update_timestamps=True)
+                                              update_solr=True, set_processed_timestamp=True)
 
         # verify database was updated propery
         with self.app.session_scope() as session:

--- a/adsmp/tests/test_run.py
+++ b/adsmp/tests/test_run.py
@@ -14,7 +14,7 @@ class TestFixDbDuplicates(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.postgresql = \
-            testing.postgresql.Postgresql(host='127.0.0.1', port=15678, user='postgres', 
+            testing.postgresql.Postgresql(host='127.0.0.1', port=15678, user='postgres',
                                           database='test')
 
     @classmethod
@@ -56,7 +56,7 @@ class TestFixDbDuplicates(unittest.TestCase):
             queue_bibcodes.assert_called_with([u'bibcode2', u'bibcode3'],
                                               force=True, ignore_checksums=True,
                                               update_links=True, update_metrics=True,
-                                              update_solr=True, set_processed_timestamp=True)
+                                              update_solr=True, update_processed=True)
 
         # verify database was updated propery
         with self.app.session_scope() as session:

--- a/adsmp/validate.py
+++ b/adsmp/validate.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from builtins import map
 from builtins import object
-from past.utils import old_div
 import os
 import time
 import requests
@@ -13,23 +12,23 @@ class Validate(object):
     """Validates the output of a new pipeline by comparing its SOLR instance against
     that of a previous pipeline version"""
 
-    def __init__(self,fields,ignore_fields,new_fields):
+    def __init__(self, fields, ignore_fields, new_fields):
         self.fields = fields
         self.ignore_fields = ignore_fields
         self.new_fields = new_fields
 
         # - Use app logger:
-        #import logging
-        #self.logger = logging.getLogger('master-pipeline')
+        # import logging
+        # self.logger = logging.getLogger('master-pipeline')
         # - Or individual logger for this file:
         from adsputils import setup_logging, load_config
         proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
         self.config = load_config(proj_home=proj_home)
         self.logger = setup_logging(__name__, proj_home=proj_home,
-                                level=self.config.get('LOGGING_LEVEL', 'INFO'),
-                                attach_stdout=self.config.get('LOG_STDOUT', False))
+                                    level=self.config.get('LOGGING_LEVEL', 'INFO'),
+                                    attach_stdout=self.config.get('LOG_STDOUT', False))
 
-    def compare_solr(self, bibcodelist=None,filename=None):
+    def compare_solr(self, bibcodelist=None, filename=None):
 
         if (bibcodelist is None) and (filename is None):
             raise RuntimeError('Must pass in a list of bibcodes or a file of bibcodes')
@@ -69,7 +68,7 @@ class Validate(object):
                 Validate.pipeline_mismatch(self, bibcode, s1, s2)
 
         tottime = time.time() - t1
-        self.logger.info('Time elapsed to compare {} bibcodes: {} s'.format(len(bibcodes),tottime))
+        self.logger.info('Time elapsed to compare {} bibcodes: {} s'.format(len(bibcodes), tottime))
 
     def query_solr(self, endpoint, query, start=0, rows=200, sort="date desc", fl='bibcode'):
         d = {'q': query,
@@ -88,7 +87,7 @@ class Validate(object):
         if response.status_code == 200:
             results = response.json()
             return results
-        self.logger.warn('For query {}, there was a network problem: {0}\n'.format(query,response))
+        self.logger.warn('For query {}, there was a network problem: {0}\n'.format(query, response))
         return None
 
     def pipeline_mismatch(self, bibcode, s1, s2):
@@ -120,9 +119,8 @@ class Validate(object):
 
         self.logger.info('The following fields are ignored: {}'.format(self.ignore_fields))
         self.logger.info('Mismatch stats for bibcode {}: {} mismatches, {} missing required new fields, '
-                               '{} fields not in old database, {} fields not in new database, '
-                               '{} fields not in either database'.format(bibcode,mismatch,missing_required,notins1,notins2,missing))
-
+                         '{} fields not in old database, {} fields not in new database, '
+                         '{} fields not in either database'.format(bibcode, mismatch, missing_required, notins1, notins2, missing))
 
     def fields_match(self, bibcode, s1, s2, field):
 
@@ -131,16 +129,16 @@ class Validate(object):
             f2 = s2[field]
         elif (field not in s1) and (field not in s2):
             if field in self.new_fields:
-                self.logger.warn('Bibcode {}: required new field {} not present'.format(bibcode,field))
+                self.logger.warn('Bibcode {}: required new field {} not present'.format(bibcode, field))
                 return 'required new field not in bibcode'
             else:
-                self.logger.info('Bibcode {}: field {} not present in either database'.format(bibcode,field))
+                self.logger.info('Bibcode {}: field {} not present in either database'.format(bibcode, field))
                 return 'field not in bibcode'
         elif field not in s1:
-            self.logger.info('Bibcode {}: field {} not present in old database'.format(bibcode,field))
+            self.logger.info('Bibcode {}: field {} not present in old database'.format(bibcode, field))
             return 'field not in s1'
         elif field not in s2:
-            self.logger.info('Bibcode {}: field {} not present in new database'.format(bibcode,field))
+            self.logger.info('Bibcode {}: field {} not present in new database'.format(bibcode, field))
             return 'field not in s2'
 
         # for citations, sort and compare the lists
@@ -162,7 +160,7 @@ class Validate(object):
 
         # allow cite_read_boost to differ by up to 10%, unless one field is 0 and the other is non-zero
         if field == 'cite_read_boost':
-            if (f1 ==0.) and (f2 == 0.):
+            if (f1 == 0.) and (f2 == 0.):
                 return True
             elif (f1 == 0. and f2 != 0.) or (f1 != 0. and f2 == 0.):
                 self.logger.warn(
@@ -195,7 +193,7 @@ class Validate(object):
         # for identifier, sort first before comparing, since the order has changed
         if field == 'identifier':
             if sorted(f1) != sorted(f2):
-                self.logger.warn('Bibcode {}: identifier field is different between databases. Old: {} New: {}'.format(bibcode,f1,f2))
+                self.logger.warn('Bibcode {}: identifier field is different between databases. Old: {} New: {}'.format(bibcode, f1, f2))
                 return False
             else:
                 return True
@@ -219,7 +217,7 @@ class Validate(object):
                         self.logger.warn(
                             'Bibcode %s: unicode field %s is different between databases.', bibcode, field,)
                     else:
-                        self.logger.warn('Bibcode %s: unicode field %s is different between databases. Old: %r New: %r',bibcode,field,f1,f2)
+                        self.logger.warn('Bibcode %s: unicode field %s is different between databases. Old: %r New: %r', bibcode, field, f1, f2)
                     return False
                 else:
                     if field == 'body':
@@ -227,9 +225,9 @@ class Validate(object):
                             'Bibcode %s: unicode field %s is slightly different between databases.',
                             bibcode, field)
                     else:
-                        self.logger.info('Bibcode %s: unicode field %s is slightly different between databases. Old: %r New: %r',bibcode,field,f1,f2)
+                        self.logger.info('Bibcode %s: unicode field %s is slightly different between databases. Old: %r New: %r', bibcode, field, f1, f2)
             else:
-                self.logger.warn('Bibcode {}: field {} is different between databases. Old: {} New: {}'.format(bibcode,field,f1,f2))
+                self.logger.warn('Bibcode {}: field {} is different between databases. Old: {} New: {}'.format(bibcode, field, f1, f2))
                 return False
 
         return True

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import adsputils
 import argparse
 import warnings
@@ -8,44 +9,42 @@ import json
 from requests.packages.urllib3 import exceptions
 warnings.simplefilter('ignore', exceptions.InsecurePlatformWarning)
 import time
-import requests
-from difflib import SequenceMatcher
 from pyrabbit.api import Client as PyRabbitClient
 from urlparse import urlparse
 
-from adsputils import setup_logging, get_date
+from adsputils import setup_logging, get_date, load_config
 from adsmp.models import KeyValue, Records
 from adsmp import tasks, solr_updater, validate
 from sqlalchemy.orm import load_only
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 # ============================= INITIALIZATION ==================================== #
-
-from adsputils import setup_logging, load_config
 proj_home = os.path.realpath(os.path.dirname(__file__))
 config = load_config(proj_home=proj_home)
 logger = setup_logging('run.py', proj_home=proj_home,
-                        level=config.get('LOGGING_LEVEL', 'INFO'),
-                        attach_stdout=config.get('LOG_STDOUT', False))
+                       level=config.get('LOGGING_LEVEL', 'INFO'),
+                       attach_stdout=config.get('LOG_STDOUT', False))
 
 app = tasks.app
 
 # =============================== FUNCTIONS ======================================= #
 
+
 def _print_record(bibcode):
     with app.session_scope() as session:
-        print 'stored by us:', bibcode
+        print('stored by us:', bibcode)
         r = session.query(Records).filter_by(bibcode=bibcode).first()
         if r:
-            print json.dumps(r.toJSON(), indent=2, default=str, sort_keys=True)
+            print(json.dumps(r.toJSON(), indent=2, default=str, sort_keys=True))
         else:
-            print 'None'
-        print '-' * 80
+            print('None')
+        print('-' * 80)
 
-        print 'as seen by SOLR'
+        print('as seen by SOLR')
         solr_doc = solr_updater.transform_json_record(r.toJSON())
-        print json.dumps(solr_doc, indent=2, default=str, sort_keys=True)
-        print '=' * 80
+        print(json.dumps(solr_doc, indent=2, default=str, sort_keys=True))
+        print('=' * 80)
+
 
 def diagnostics(bibcodes):
     """
@@ -55,7 +54,7 @@ def diagnostics(bibcodes):
     """
 
     if not bibcodes:
-        print 'Printing 3 randomly selected records (if any)'
+        print('Printing 3 randomly selected records (if any)')
         bibcodes = []
         with app.session_scope() as session:
             for r in session.query(Records).limit(3).all():
@@ -64,25 +63,23 @@ def diagnostics(bibcodes):
     for b in bibcodes:
         _print_record(b)
 
-
     with app.session_scope() as session:
         for x in dir(Records):
             if isinstance(getattr(Records, x), InstrumentedAttribute):
-                print '# of %s' % x, session.query(Records).filter(getattr(Records, x) != None).count()
+                print('# of %s' % x, session.query(Records).filter(getattr(Records, x) != None).count())
 
-    print 'sending test bibcodes to the queue for reindexing'
+    print('sending test bibcodes to the queue for reindexing')
     tasks.task_index_records.delay(bibcodes, force=True, update_solr=True, update_metrics=True, update_links=True,
                                    ignore_checksums=True)
 
 
-
 def print_kvs():
     """Prints the values stored in the KeyValue table."""
-    print 'Key, Value from the storage:'
-    print '-' * 80
+    print('Key, Value from the storage:')
+    print('-' * 80)
     with app.session_scope() as session:
         for kv in session.query(KeyValue).order_by('key').yield_per(100):
-            print kv.key, kv.value
+            print(kv.key, kv.value)
 
 
 def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True, update_metrics=True,
@@ -97,12 +94,11 @@ def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True,
         key = 'last.reindex.normal'
 
     if update_solr and update_metrics:
-        pass # default
+        pass  # default
     elif update_solr:
         key = key + '.solr-only'
     else:
         key = key + '.metrics-only'
-
 
     previous_since = None
     now = get_date()
@@ -120,7 +116,6 @@ def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True,
             session.commit()
     else:
         since = get_date(since)
-
 
     logger.info('Sending records changed since: %s', since.isoformat())
     sent = 0
@@ -143,7 +138,7 @@ def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True,
                 updated = get_date(rec.updated)
 
                 if not force_processing and processed > updated:
-                    continue # skip records that were already processed
+                    continue  # skip records that were already processed
 
                 sent += 1
                 if sent % 1000 == 0:
@@ -327,7 +322,7 @@ if __name__ == '__main__':
                         nargs='?',
                         dest='reindex',
                         action='store',
-                        const = 'sml',
+                        const='sml',
                         default='sml',
                         help='Sent all updated documents to SOLR/Postgres (you can combine with --since).' +
                         'Default is to update both solr and metrics. You can choose what to update.' +
@@ -423,11 +418,11 @@ if __name__ == '__main__':
                       'page_count', 'page_range')
 
         d = validate.Validate(fields, ignore_fields, new_fields)
-        d.compare_solr(bibcodelist=args.bibcodes,filename=args.filename)
+        d.compare_solr(bibcodelist=args.bibcodes, filename=args.filename)
 
     elif args.delete:
         if args.filename:
-            print 'deleting bibcodes from file via queue'
+            print('deleting bibcodes from file via queue')
             bibs = []
             with open(args.filename, 'r') as f:
                 for line in f:
@@ -435,7 +430,7 @@ if __name__ == '__main__':
                     if bibcode:
                         tasks.task_delete_documents(bibcode)
         else:
-            print 'please provide a file of bibcodes to delete via -n'
+            print('please provide a file of bibcodes to delete via -n')
 
     elif args.augment:
         if args.filename:
@@ -458,7 +453,7 @@ if __name__ == '__main__':
         print 'reindexing to solr url ' + str(solr_urls)
 
         if args.filename:
-            print 'sending bibcodes from file to the queue for reindexing'
+            print('sending bibcodes from file to the queue for reindexing')
             bibs = []
             with open(args.filename) as f:
                 for line in f:
@@ -478,7 +473,7 @@ if __name__ == '__main__':
                                                    solr_targets=solr_urls)
                     bibs = []
         else:
-            print 'sending bibcode since date to the queue for reindexing'
+            print('sending bibcode since date to the queue for reindexing')
             reindex(since=args.since, batch_size=args.batch_size, force_indexing=args.force_indexing,
                     update_solr=update_solr, update_metrics=update_metrics,
                     update_links = update_links, force_processing=args.force_processing, ignore_checksums=args.ignore_checksums,

--- a/run.py
+++ b/run.py
@@ -21,6 +21,8 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 # ============================= INITIALIZATION ==================================== #
 proj_home = os.path.realpath(os.path.dirname(__file__))
 config = load_config(proj_home=proj_home)
+set_processed_timestamp = config.get('SET_PROCESSED_TIMESTAMP', True)
+
 logger = setup_logging('run.py', proj_home=proj_home,
                        level=config.get('LOGGING_LEVEL', 'INFO'),
                        attach_stdout=config.get('LOG_STDOUT', False))
@@ -212,8 +214,8 @@ def rebuild_collection(collection_name):
     with app.session_scope() as session:
         # master db only contains valid documents, indexing task will make sure that incomplete docs are rejected
         for rec in session.query(Records) \
-            .options(load_only(Records.bibcode, Records.updated, Records.processed)) \
-            .yield_per(1000):
+                          .options(load_only(Records.bibcode)) \
+                          .yield_per(1000):
 
             sent += 1
             if sent % 1000 == 0:
@@ -222,9 +224,9 @@ def rebuild_collection(collection_name):
             batch.append(rec.bibcode)
             if len(batch) > 1000:
                 t = tasks.task_rebuild_index.delay(batch, force=True, update_solr=True,
-                                           update_metrics=False, update_links=False,
-                                           ignore_checksums=True, solr_targets=solr_urls,
-                                           update_timestamps=False)
+                                                   update_metrics=False, update_links=False,
+                                                   ignore_checksums=True, solr_targets=solr_urls,
+                                                   set_processed_timestamp=False)
                 _tasks.append(t)
                 batch = []
 
@@ -232,7 +234,7 @@ def rebuild_collection(collection_name):
         t = tasks.task_rebuild_index.delay(batch, force=True, update_solr=True,
                                            update_metrics=False, update_links=False,
                                            ignore_checksums=True, solr_targets=solr_urls,
-                                           update_timestamps=False)
+                                           set_processed_timestamp=False)
         _tasks.append(t)
 
     logger.info('Done queueing bibcodes for rebuilding collection %s', collection_name)
@@ -264,12 +266,12 @@ def reindex_failed(app):
             if len(bibs) >= 100:
                 session.commit()
                 tasks.task_index_records.delay(bibs, update_solr=True, update_metrics=True, update_links=True,
-                                               update_timestamps=True, force=True, ignore_checksums=True)
+                                               set_processed_timestamp=set_processed_timestamp, force=True, ignore_checksums=True)
                 bibs = []
         if bibs:
             session.commit()
             tasks.task_index_records.delay(bibs, update_solr=True, update_metrics=True, update_links=True,
-                                           update_timestamps=True, force=True, ignore_checksums=True)
+                                           set_processed_timestamp=set_processed_timestamp, force=True, ignore_checksums=True)
             bibs = []
         logger.info('Done reindexing %s previously failed bibcodes', count)
 
@@ -386,7 +388,7 @@ if __name__ == '__main__':
                         action='store',
                         default=0,
                         type=int,
-                        help='priority to use in queue, typically cron jobs use a high priority')
+                        help='priority to use in queue, typically cron jobs use a high priority.  preferred values are 1 to 10 where 10 is the highest priority')
 
     args = parser.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -83,7 +83,7 @@ def print_kvs():
 
 
 def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True, update_metrics=True,
-            update_links=True, force_processing=False, ignore_checksums=False, solr_targets=None):
+            update_links=True, force_processing=False, ignore_checksums=False, solr_targets=None, priority=0):
     """
     Initiates routing of the records (everything that was updated)
     since point in time T.
@@ -152,17 +152,17 @@ def reindex(since=None, batch_size=None, force_indexing=False, update_solr=True,
                     batch.append(rec.bibcode)
                     tasks.task_index_records.delay(batch, force=force_indexing, update_solr=update_solr,
                                                    update_metrics=update_metrics, update_links=update_links,
-                                                   ignore_checksums=ignore_checksums, solr_targets=solr_targets)
+                                                   ignore_checksums=ignore_checksums, solr_targets=solr_targets, priority=priority)
                     batch = []
                     last_bibcode = rec.bibcode
 
         if len(batch) > 0:
             tasks.task_index_records.delay(batch, force=force_indexing, update_solr=update_solr, update_metrics=update_metrics,
-                                           commit=force_indexing, ignore_checksums=ignore_checksums, solr_targets=solr_targets)
+                                           commit=force_indexing, ignore_checksums=ignore_checksums, solr_targets=solr_targets, priority=priority)
         elif force_indexing and last_bibcode:
             # issue one extra call with the commit
             tasks.task_index_records.delay([last_bibcode], force=force_indexing, update_solr=update_solr, update_metrics=update_metrics,
-                                           commit=force_indexing, ignore_checksums=ignore_checksums, solr_targets=solr_targets)
+                                           commit=force_indexing, ignore_checksums=ignore_checksums, solr_targets=solr_targets, priority=priority)
 
         logger.info('Done processing %s records', sent)
     except Exception, e:
@@ -381,6 +381,12 @@ if __name__ == '__main__':
                         action='store_true',
                         default=False,
                         help='Will send all solr docs for indexing to another collection; by purpose this task is synchronous. You can send the name of the collection or the full url to the solr instance incl http via --solr-collection')
+    parser.add_argument('--priority',
+                        dest='priority',
+                        action='store',
+                        default=0,
+                        type=int,
+                        help='priority to use in queue, typically cron jobs use a high priority')
 
     args = parser.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 # ============================= INITIALIZATION ==================================== #
 proj_home = os.path.realpath(os.path.dirname(__file__))
 config = load_config(proj_home=proj_home)
-set_processed_timestamp = config.get('SET_PROCESSED_TIMESTAMP', True)
+update_processed = config.get('UPDATE_TIMESTAMPS', True) # TODO: This probably would be better handled with an argument flag
 
 logger = setup_logging('run.py', proj_home=proj_home,
                        level=config.get('LOGGING_LEVEL', 'INFO'),
@@ -223,18 +223,12 @@ def rebuild_collection(collection_name):
 
             batch.append(rec.bibcode)
             if len(batch) > 1000:
-                t = tasks.task_rebuild_index.delay(batch, force=True, update_solr=True,
-                                                   update_metrics=False, update_links=False,
-                                                   ignore_checksums=True, solr_targets=solr_urls,
-                                                   set_processed_timestamp=False)
+                t = tasks.task_rebuild_index.delay(batch, solr_targets=solr_urls)
                 _tasks.append(t)
                 batch = []
 
     if len(batch) > 0:
-        t = tasks.task_rebuild_index.delay(batch, force=True, update_solr=True,
-                                           update_metrics=False, update_links=False,
-                                           ignore_checksums=True, solr_targets=solr_urls,
-                                           set_processed_timestamp=False)
+        t = tasks.task_rebuild_index.delay(batch, solr_targets=solr_urls)
         _tasks.append(t)
 
     logger.info('Done queueing bibcodes for rebuilding collection %s', collection_name)
@@ -266,12 +260,12 @@ def reindex_failed(app):
             if len(bibs) >= 100:
                 session.commit()
                 tasks.task_index_records.delay(bibs, update_solr=True, update_metrics=True, update_links=True,
-                                               set_processed_timestamp=set_processed_timestamp, force=True, ignore_checksums=True)
+                                               update_processed=update_processed, force=True, ignore_checksums=True)
                 bibs = []
         if bibs:
             session.commit()
             tasks.task_index_records.delay(bibs, update_solr=True, update_metrics=True, update_links=True,
-                                           set_processed_timestamp=set_processed_timestamp, force=True, ignore_checksums=True)
+                                           update_processed=update_processed, force=True, ignore_checksums=True)
             bibs = []
         logger.info('Done reindexing %s previously failed bibcodes', count)
 


### PR DESCRIPTION
This PR has not been tested, unit test will most certainly fail and it is not supposed to be merged as it is. This PR is to facilitate communication to address issues in Master Pipeline and the PR https://github.com/adsabs/ADSMasterPipeline/pull/145.

List of changes:

- Rebase to current HEAD to incorporate changes from https://github.com/adsabs/ADSMasterPipeline/pull/147
- Optimization: Compute checksum only once (before it was computed when deciding if an entry needs to be indexed + when the entry was successfully indexed)
- Added checksum argument to index_solr, index_metrics, and index_datalinks to store it in the DB if index succeeds
- Renamed 'set_processed_timestamp' to 'update_processed'
- Optimization: Consolidated update of timestamps, status and checksums in a single method 'mark_processed' (before we had duplicated code and certain fields could be updated in different places for the same bibcode, requiring two or more selects to find the bibcode row)
- If 'update_processed' is True, call 'mark_processed' after bulk or individual successes to update timestamp, checksum, and status
- If 'update_processed' is True, call 'mark_processed' after failures to update timestamp, and status
- Implemented one-by-one strategy if bulk call to update datalinks fail, this way we have very similar patterns in all indexing functions (index_solr, index_metrics, and index_datalinks)
- Removed unused arguments for 'task_rebuild_index'
- Use of apply_sync to properly set message priorities. 'delay' does not allow to change message priorities, adding an argument only send that data to the task but does not affect anything else. See docs for [delay](https://docs.celeryproject.org/en/stable/reference/celery.app.task.html#celery.app.task.Task.delay) and [apply_sync](https://docs.celeryproject.org/en/stable/reference/celery.app.task.html#celery.app.task.Task.apply_async)
