### PR TITLE
Reducing logging from affiliation/augment requests

### DIFF
--- a/adsmp/app.py
+++ b/adsmp/app.py
@@ -734,7 +734,7 @@ class ADSMasterPipelineCelery(ADSCelery):
         if data and data['aff']:
             message = AugmentAffiliationRequestRecord(**data)
             self.forward_message(message)
-            self.logger.info('sent augment affiliation request for bibcode {}'.format(bibcode))
+            self.logger.debug('sent augment affiliation request for bibcode {}'.format(bibcode))
         else:
             self.logger.warning('request_aff_augment called but bibcode {} has no aff data'.format(bibcode))
 

--- a/adsmp/tasks.py
+++ b/adsmp/tasks.py
@@ -91,7 +91,7 @@ def task_update_record(msg):
             if type == 'metadata':
                 # with new bib data we request to augment the affiliation
                 # that pipeline will eventually respond with a msg to task_update_record
-                logger.info('requesting affilation augmentation for %s', msg.bibcode)
+                logger.debug('requesting affilation augmentation for %s', msg.bibcode)
                 app.request_aff_augment(msg.bibcode)
 
     else:


### PR DESCRIPTION
Augment pipeline requests are currently generating two logging messages per bibcode, one from app, and one from tasks.  This can potentially generate millions of messages during weekend reindexes and manual augment updates.  These messages are intended more as debugging messages, and so both have been changed to logger.debug.  Logging messages will still be generated by warning/error conditions.