### PR TITLE
we still need extended timeout

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -119,7 +119,7 @@ def run():
                         if t > commit_time:
                             finished = True
                         time_waiting = datetime.datetime.utcnow() - commit_time
-                        if (time_waiting.seconds > 3600):
+                        if (time_waiting.seconds > (3600 * 2)):
                             logger.warn('Solr commit running for over two  hours, aborting')
                             raise
             if not finished:


### PR DESCRIPTION
optimazations ends up with longer queues for indexing solr so we need the longer timeout