### PR TITLE
Attempt to avoid a commit request that does not return for an extended time

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -97,7 +97,7 @@ def run():
 
         # issue commit
         commit_time = datetime.datetime.utcnow()
-        r = requests.get(update_url + '?commit=true')
+        r = requests.get(update_url + '?commit=true&waitSearcher=false')
         r.raise_for_status()
         logger.info('Issued async commit to SOLR')
 
@@ -119,8 +119,8 @@ def run():
                         if t > commit_time:
                             finished = True
                         time_waiting = datetime.datetime.utcnow() - commit_time
-                        if (time_waiting.seconds > (3600 * 2)):
-                            logger.warn('Solr commit running for over two  hours, aborting')
+                        if (time_waiting.seconds > (3600 * 3)):
+                            logger.warn('Solr commit running for over three hours, aborting')
                             raise
             if not finished:
                 time.sleep(30)
@@ -223,7 +223,7 @@ def monitor_solr_writes():
                 logger.info('monitoring docsPending with current_docs_pending {}, previous_docs_pending {}, consecutive_match_count {}'.format(current_docs_pending, previous_docs_pending, consecutive_match_count))
                 time.sleep(30)
     logger.info('completed monitoring of docsPending on solr with current_docs_pending {}, previous_docs_pending {}, consecutive_match_count {}'.format(current_docs_pending, previous_docs_pending, consecutive_match_count))
-    
+
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
When we rebuild and we make the last commit, we are suffering problems such as:

```
Traceback (most recent call last):
  File \"scripts/reindex.py\", line 100, in run
    r = requests.get(update_url + '?commit=true')
  File \"/usr/local/lib/python3.8/dist-packages/requests/api.py\", line 75, in get
    return request('get', url, params=params, **kwargs)
  File \"/usr/local/lib/python3.8/dist-packages/requests/api.py\", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File \"/usr/local/lib/python3.8/dist-packages/requests/sessions.py\", line 524, in request
    resp = self.send(prep, **send_kwargs)
  File \"/usr/local/lib/python3.8/dist-packages/requests/sessions.py\", line 637, in send
    r = adapter.send(request, **kwargs)
  File \"/usr/local/lib/python3.8/dist-packages/requests/adapters.py\", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"
```

Solr documentation says default is "true" for waitSearcher (see https://solr.apache.org/guide/7_4/uploading-data-with-index-handlers.html)