### PR TITLE
Adjust metrics id column to use BigInteger to prevent overflow.

### DIFF
--- a/adsmp/models.py
+++ b/adsmp/models.py
@@ -195,7 +195,7 @@ class SitemapInfo(Base):
 class MetricsModel(MetricsBase):
     __tablename__ = 'metrics'
     __bind_key__ = 'metrics'
-    id = Column(Integer, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     bibcode = Column(String, nullable=False, index=True, unique=True)
 
     an_citations = Column(postgresql.REAL)


### PR DESCRIPTION
Complementary fix for adsabs/metrics_service#147